### PR TITLE
Fixed XACML policy template for roles: 'role.id' should be 'role_id' …

### DIFF
--- a/openstack_dashboard/templates/access_control/policy.xacml
+++ b/openstack_dashboard/templates/access_control/policy.xacml
@@ -1,4 +1,4 @@
-<Policy PolicyId="{{role.id}}" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-unless-permit">
+<Policy PolicyId="{{role_id}}" Version="1.0" RuleCombiningAlgId="urn:oasis:names:tc:xacml:3.0:rule-combining-algorithm:deny-unless-permit">
   <Description>Role {{ role_id }} from application {{ app_id }}</Description>
   <Target>
     <AnyOf>


### PR DESCRIPTION
There is a typo in PolicyId attribute in the access_control/policy.xacml template: 'role.id' instead of 'role_id'. This is causing all PolicyIds to be empty strings in the PDP (causing Policy conflicts during evaluation).
