### PR TITLE
Update access_control_ge.py

### DIFF
--- a/openstack_dashboard/fiware_api/access_control_ge.py
+++ b/openstack_dashboard/fiware_api/access_control_ge.py
@@ -82,7 +82,7 @@ def policyset_update(request, application, role_permissions):
 
     if not settings.ACCESS_CONTROL_MAGIC_KEY:
         LOG.warning('ACCESS_CONTROL_MAGIC_KEY setting is not set.')
-        return 
+        # return 
 
     app_id = application.id
     policy_id = str(uuid.uuid4())


### PR DESCRIPTION
policy_update function MUST NOT return if settings.ACCESS_CONTROL_MAGIC_KEY does not exist, because is an optional parameter. X-Auth-Token header is simply ignored when the PDP is not behind a PEP Proxy. If return is present, the communication with the PDP never takes place despite everything is correct.