### PR TITLE
Remove hardcoded protocol when building the logout URL

### DIFF
--- a/openstack_dashboard/static/fiware/signOut.js
+++ b/openstack_dashboard/static/fiware/signOut.js
@@ -86,18 +86,18 @@ Fiware.signOut = (function($, undefined) {
   var finish = function() {
     // Use window.debugSignOut to debug
     if (window.debugSignOut === undefined) {
-      window.location.replace('http://' + domain);
+      window.location.replace(window.location.protocol + '//' + domain);
     }
   };
 
   // Development environment
   var developmentCall = function(currentPortal) {
-    var url = 'http://' + window.location.host + portals[currentPortal].path;
+    var url = window.location.protocol + '//' + window.location.host + portals[currentPortal].path;
 
     $.ajax(url, {
       type: portals[currentPortal].verb,
       success: function() {
-        window.location.replace('http://' + window.location.host);
+        window.location.replace(window.location.protocol + '//' + window.location.host);
       }
     });
   };


### PR DESCRIPTION
This bug is preventing logging out from the IdM when configuring it to use https. Take into account that any IdM instance other that the FIWARE Lab's one is considered a to be in a development environment (that's the point of having to fix the `developmentCall` method).